### PR TITLE
CompileStatic compatability with event bus subscription

### DIFF
--- a/src/rt/groovy/net/thesilkminer/mc/austin/rt/EventMetaFactory.groovy
+++ b/src/rt/groovy/net/thesilkminer/mc/austin/rt/EventMetaFactory.groovy
@@ -26,6 +26,9 @@ package net.thesilkminer.mc.austin.rt
 
 import groovy.transform.CompileStatic
 import groovy.transform.PackageScope
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.FromString
+import net.minecraftforge.eventbus.api.Event
 import net.minecraftforge.eventbus.api.EventPriority
 import net.minecraftforge.eventbus.api.IEventBus
 
@@ -42,16 +45,16 @@ final class EventMetaFactory {
         }
     }
 
-    static void subscribeToBus(
+    static <T extends Event> void subscribeToBus(
             final Closure<?> originalCall,
             final maybeBus,
             final EventPriority maybePriority,
             final Boolean maybeReceiveCancelled,
             final Class<?> maybeGenericType,
-            final Class<?> eventTypeReference,
+            final Class<T> eventTypeReference,
             final methodPointerOwner,
             final methodPointerName,
-            final Closure<?> subscriber
+            @ClosureParams(value = FromString, options = "T") final Closure<?> subscriber
     ) {
         if (!(maybeBus instanceof IEventBus)) {
             originalCall()


### PR DESCRIPTION
From what we discussed in Discord earlier:

Add ClosureParam annotation to event subscriber parameter. I would use something other than FromString, but the other options weren't looking to great in terms of IDE support, though they compiled fine.

Le me know if I should make changes, or if you'd like it on 1.18 too, though you can probably just do the exact same thing there.